### PR TITLE
Make connections to the region specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+/rds_create_freestoragespace_alarms.egg-info/

--- a/rds_create_freestoragespace_alarms/main.py
+++ b/rds_create_freestoragespace_alarms/main.py
@@ -4,7 +4,7 @@
 Script used to create a below 20 pct. Low-FreeStorageSpace alarm
 in AWS CloudWatch for all RDS instances
 
-e.g rds-create-freestoragespace-alarms us-west-1 arn:aws:sns:us-west-1:1234567:abc
+e.g rds-create-freestoragespace-alarms us-west-1 arn:aws:sns:us-west-1:1234:abc
 
 Usage:
     rds-create-freestoragespace-alarms [options] <region> <alarm_arn>

--- a/rds_create_freestoragespace_alarms/main.py
+++ b/rds_create_freestoragespace_alarms/main.py
@@ -4,15 +4,18 @@
 Script used to create a below 20 pct. Low-FreeStorageSpace alarm
 in AWS CloudWatch for all RDS instances
 
+e.g rds-create-freestoragespace-alarms us-west-1 arn:aws:sns:us-west-1:1234567:abc
+
 Usage:
-    rds-create-freestoragespace-alarms [options]
-    rds-create-freestoragespace-alarms [-h | --help]
+    rds-create-freestoragespace-alarms [options] <region> <alarm_arn>
+    rds-create-freestoragespace-alarms -h | --help
 
 Options:
      --debug   Don't send data to AWS
 
 """
 import boto.ec2
+import boto.ec2.cloudwatch
 import boto.rds2
 from docopt import docopt
 from boto.ec2.cloudwatch import MetricAlarm
@@ -20,18 +23,26 @@ from boto.ec2.cloudwatch import MetricAlarm
 DEBUG = False
 
 
-def get_rds_instances():
+def get_rds_instances(region):
     """
     Retreives the list of all RDS instances
+
+    Args:
+        region (str): Region of the RDS to get
 
     Returns:
         (list) List of valid state RDS instances
     """
-    rds = boto.connect_rds2()
-    response = rds.describe_db_instances()
-    rds_instances = (response[u'DescribeDBInstancesResponse']
-                             [u'DescribeDBInstancesResult']
-                             [u'DBInstances'])
+    assert isinstance(region, str)
+
+    rds = boto.rds2.connect_to_region(region)
+    if rds:
+        response = rds.describe_db_instances()
+        rds_instances = (response[u'DescribeDBInstancesResponse']
+                                 [u'DescribeDBInstancesResult']
+                                 [u'DBInstances'])
+    else:
+        rds_instances = []
 
     return rds_instances
 
@@ -59,13 +70,16 @@ def get_existing_freestoragespace_alarm_names(aws_cw_connect):
 
 
 def get_freestoragespace_alarms_to_create(rds_instances,
-                                          aws_cw_connect):
+                                          aws_cw_connect,
+                                          alarm_action):
     """
     Creates a Low-FreeStorageSpace alarm for all RDS instances
 
     Args:
         rds_instances (list) ist of all RDS instances
         aws_cw_connect (CloudWatchConnection)
+        alarm_action (str): ARN of the cloudwatch alarm action
+                            e.g. arn:aws:sns:us-west-1:1234567:abc
 
     Returns:
         (set) All Low-FreeStorageSpace alarms that will be created
@@ -73,6 +87,7 @@ def get_freestoragespace_alarms_to_create(rds_instances,
     assert isinstance(rds_instances, list)
     assert isinstance(aws_cw_connect,
                       boto.ec2.cloudwatch.CloudWatchConnection)
+    assert isinstance(alarm_action, str)
 
     alarms_to_create = set()
     existing_alarms = get_existing_freestoragespace_alarm_names(aws_cw_connect)
@@ -92,7 +107,7 @@ def get_freestoragespace_alarms_to_create(rds_instances,
             comparison=u'<',
             threshold=(0.20*instance[u'AllocatedStorage'])*1000000000,
             period=60, evaluation_periods=5,
-            alarm_actions=[u'arn:aws:sns:us-west-1:667005031541:ops'],
+            alarm_actions=[alarm_action],
             dimensions={u'DBInstanceIdentifier':
                         instance[u'DBInstanceIdentifier']})
 
@@ -110,10 +125,13 @@ def main():
     if args['--debug']:
         DEBUG = True
 
-    rds_instances = get_rds_instances()
-    aws_cw_connect = boto.connect_cloudwatch()
+    region = args['<region>']
+    alarm_action = args['<alarm_arn>']
+    rds_instances = get_rds_instances(region)
+    aws_cw_connect = boto.ec2.cloudwatch.connect_to_region(region)
     alarms_to_create = get_freestoragespace_alarms_to_create(rds_instances,
-                                                             aws_cw_connect)
+                                                             aws_cw_connect,
+                                                             alarm_action)
 
     if alarms_to_create:
         if DEBUG:
@@ -122,7 +140,6 @@ def main():
         else:
             print 'New RDS Low-FreeStorageSpace Alarms created:'
             for alarm in alarms_to_create:
-                print alarm
                 aws_cw_connect.create_alarm(alarm)
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='rds-create-freestoragespace-alarms',
-    version='1.1',
+    version='1.2',
     description='AWS Cloudwatch RDS Tool for creating Metric Alarms',
     url='https://github.com/percolate/rds-create-freestoragespace-alarms',
     author='Mihailo Pavlisin',


### PR DESCRIPTION
https://percolate.atlassian.net/browse/DTST-63

This fixes the problem where a change in configuration can lead to some
connections on different regions, unable to interact together (e.g. RDS
in one, and alarms in another)

Tested locally, alarms already created:
```
[analogue:~/src/rds-create-freestoragespace-alarms] fix_invalid_region(+35/-15)* ± rds-create-freestoragespace-alarms --debug us-west-1 arn:aws:sns:us-west-1:667005031541:ops
DEBUG: MetricAlarm:RDS-pam-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-qa-pekoe-pg-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 1000000000.0]
DEBUG: MetricAlarm:RDS-pident-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-users-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-qa-chai-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 10000000000.0]
DEBUG: MetricAlarm:RDS-sasquatch-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-sentry-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-mediabroker-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-sentry8-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-pif-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-media-slave-fivetran-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 40000000000.0]
DEBUG: MetricAlarm:RDS-users-slave-fivetran-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-melrose-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-qa-legacy-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 10000000000.0]
DEBUG: MetricAlarm:RDS-paid-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-redeye-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
DEBUG: MetricAlarm:RDS-qa-pekoe-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 10000000000.0]
DEBUG: MetricAlarm:RDS-qa-chai-pg-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 1000000000.0]

[analogue:~/src/rds-create-freestoragespace-alarms] fix_invalid_region(+34/-14)* 1 ± rds-create-freestoragespace-alarms us-west-1 arn:aws:sns:us-west-1:667005031541:ops
New RDS Low-FreeStorageSpace Alarms created:
MetricAlarm:RDS-sentry-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-paid-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-qa-pekoe-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 10000000000.0]
MetricAlarm:RDS-qa-legacy-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 10000000000.0]
MetricAlarm:RDS-sasquatch-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-pam-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-users-slave-fivetran-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-pident-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-qa-chai-pg-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 1000000000.0]
MetricAlarm:RDS-redeye-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-channels-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-users-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-config-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-qa-chai-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 10000000000.0]
MetricAlarm:RDS-qa-pekoe-pg-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 1000000000.0]
MetricAlarm:RDS-mediabroker-57-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-sentry8-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-melrose-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
MetricAlarm:RDS-pif-Low-Free-Storage-Space[FreeStorageSpace(Average) LessThanThreshold 20000000000.0]
```